### PR TITLE
Add action to create an XML/latex2edx based repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,11 @@ just install directory from github.com with ``pip install
 git+https://github.com/mitodl/orcoursetrion``.
 
 Once installed, create or acquire an `OAUTH2 token from github
-<https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`_.
+<https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`_. That
+at least has the ``repo``, ``write:repo_hook``, and ``write:org``
+permissions.
 
-Add the environment variable ``ORC_GITHUB_OAUTH2_TOKEN=<your token>``
+Add the environment variable ``ORC_GH_OAUTH2_TOKEN=<your token>``
 to your environment, and run ``orcoursetrion --help`` for available
 commands and actions.
 

--- a/README.rst
+++ b/README.rst
@@ -18,3 +18,7 @@ Once installed, create or acquire an `OAUTH2 token from github
 Add the environment variable ``ORC_GITHUB_OAUTH2_TOKEN=<your token>``
 to your environment, and run ``orcoursetrion --help`` for available
 commands and actions.
+
+If you are adding an XML course, you will also need to define
+``ORC_STAGING_GITRELOAD`` in your environment for where Web hooks
+should be sent for push events.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,3 +49,15 @@ Configuration options
 
 .. autoattribute:: orcoursetrion.config.ORC_STUDIO_DEPLOY_TEAM
    :annotation: = Deployment team for Studio Export repos
+
+.. autoattribute:: orcoursetrion.config.ORC_XML_ORG
+    :annotation: = Organization to use for XML/latex2edx courses
+
+.. autoattribute:: orcoursetrion.config.ORC_XML_DEPLOY_TEAM
+    :annotation: = Deployment team for XML/latex2edx courses
+
+.. autoattribute:: orcoursetrion.config.ORC_STAGING_GITRELOAD
+    :annotation: = `gitreload <https://github.com/mitodl/gitreload>`_
+                 server URL (including username and password) for the
+                 course development LMS.
+

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -15,3 +15,19 @@ awesome class repo'`` you should see it respond with the URL of the
 repo that it just created for you.
 
 
+Available Actions
+=================
+
+:create_export_repo:
+
+   This will create a new repository with the content deployment team
+   from :py:attr:`~orcoursetrion.config.ORC_STUDIO_DEPLOY_TEAM` added to
+   the repository.
+
+:create_xml_repo:
+
+   This will create a new repository with the
+   :py:attr:`~orcoursetrion.config.ORC_XML_DEPLOY_TEAM` and a command
+   line specified team added to repository.  It will also set up a git
+   hook to the URL specified with
+   :py:attr:`~orcoursetrion.config.ORC_STAGING_GITRELOAD`.

--- a/orcoursetrion/actions/__init__.py
+++ b/orcoursetrion/actions/__init__.py
@@ -2,9 +2,13 @@
 """
 Action library access
 """
-from orcoursetrion.actions.github import create_export_repo
+from orcoursetrion.actions.github import (
+    create_export_repo,
+    create_xml_repo
+)
 
 
 __all__ = [
     'create_export_repo',
+    'create_xml_repo',
 ]

--- a/orcoursetrion/actions/github.py
+++ b/orcoursetrion/actions/github.py
@@ -38,3 +38,45 @@ def create_export_repo(course, term, description=None):
         config.ORC_STUDIO_ORG, repo_name, config.ORC_STUDIO_DEPLOY_TEAM
     )
     return repo
+
+
+def create_xml_repo(course, term, team, description=None):
+    """Creates a course repo at
+    :py:const:`~orcoursetrion.config.ORC_GH_API_URL` with key
+    :py:const:`~orcoursetrion.config.ORC_GH_OAUTH2_TOKEN` and at
+    organization :py:const:`~orcoursetrion.config.ORC_XML_ORG`, and
+    with ``team`` as a collaborator (Along with
+    :py:const:`~orcoursetrion.config.ORC_XML_DEPLOY_TEAM`).
+
+    This also adds a github Web hook to the course development
+    environment `gitreload <https://github.com/mitodl/gitreload>`_
+    server via
+    :py:const:`~orcoursetrion.config.ORC_STAGING_GITRELOAD`.
+
+    Args:
+        course (str): Course name to be used to name repo (i.e. 6.004r)
+        term (str): Term the course is expected to run (i.e. 2015_Spring)
+        team (str): Name of the team to add read/write access to this repo.
+        description (str): Optional description for repo to show up on github
+    Returns:
+        dict: Github dictionary of a repo
+                (https://developer.github.com/v3/repos/#create)
+
+    """
+
+    github = GitHub(config.ORC_GH_API_URL, config.ORC_GH_OAUTH2_TOKEN)
+    repo_name = '{prefix}-{course}-{term}'.format(
+        prefix=config.ORC_COURSE_PREFIX,
+        course=course.replace('.', ''),
+        term=term
+    )
+    repo = github.create_repo(config.ORC_XML_ORG, repo_name, description)
+    github.add_team_repo(config.ORC_XML_ORG, repo_name, team)
+    github.add_team_repo(
+        config.ORC_XML_ORG, repo_name, config.ORC_XML_DEPLOY_TEAM
+    )
+
+    github.add_web_hook(
+        config.ORC_XML_ORG, repo_name, config.ORC_STAGING_GITRELOAD
+    )
+    return repo

--- a/orcoursetrion/actions/github.py
+++ b/orcoursetrion/actions/github.py
@@ -56,7 +56,8 @@ def create_xml_repo(course, term, team, description=None):
     Args:
         course (str): Course name to be used to name repo (i.e. 6.004r)
         term (str): Term the course is expected to run (i.e. 2015_Spring)
-        team (str): Name of the team to add read/write access to this repo.
+        team (str): Name of an organizational team that already exists to
+                    add read/write access to this repo.
         description (str): Optional description for repo to show up on github
     Returns:
         dict: Github dictionary of a repo

--- a/orcoursetrion/cmd.py
+++ b/orcoursetrion/cmd.py
@@ -19,6 +19,18 @@ def run_create_export_repo(args):
     )
 
 
+def run_create_xml_repo(args):
+    """Run the create_xml_repo action using args"""
+    repo = actions.create_xml_repo(
+        args.course, args.term, args.team, args.description
+    )
+    print(
+        'Newly created repository for XML course created at {0}'.format(
+            repo['html_url']
+        )
+    )
+
+
 def execute():
     """Execute command line orchestrion actions.
     """
@@ -51,6 +63,29 @@ def execute():
         help='Description string to set for repository'
     )
     create_export_repo.set_defaults(func=run_create_export_repo)
+
+    # Create XML repository
+    create_xml_repo = subparsers.add_parser(
+        'create_xml_repo',
+        help='Create an XML/latex2edx git repository'
+    )
+    create_xml_repo.add_argument(
+        '-c', '--course', type=str, required=True,
+        help='Course to work on (i.e. 6.0001)'
+    )
+    create_xml_repo.add_argument(
+        '-t', '--term', type=str, required=True,
+        help='Term of the course (i.e. Spring_2015)'
+    )
+    create_xml_repo.add_argument(
+        '-g', '--team', type=str, required=True,
+        help='Name of team in organization that should have access'
+    )
+    create_xml_repo.add_argument(
+        '-d', '--description', type=str,
+        help='Description string to set for repository'
+    )
+    create_xml_repo.set_defaults(func=run_create_xml_repo)
 
     # Run the action
     args = parser.parse_args()

--- a/orcoursetrion/cmd.py
+++ b/orcoursetrion/cmd.py
@@ -32,7 +32,7 @@ def run_create_xml_repo(args):
 
 
 def execute():
-    """Execute command line orchestrion actions.
+    """Execute command line orcoursetrion actions.
     """
     parser = argparse.ArgumentParser(
         prog='orcoursetrion',

--- a/orcoursetrion/config.py
+++ b/orcoursetrion/config.py
@@ -32,6 +32,15 @@ CONFIG_KEYS = [
 
     # Deployment team for studio
     ('ORC_STUDIO_DEPLOY_TEAM', 'mitx-studio-export'),
+
+    # Org to use for XML/latex2edx courses
+    ('ORC_XML_ORG', 'mitx'),
+
+    # Deployment team for XML/latex2edx
+    ('ORC_XML_DEPLOY_TEAM', 'mitx-content-deployment'),
+
+    # Web hook URL (including basic auth) for course development LMS
+    ('ORC_STAGING_GITRELOAD', None),
 ]
 for key in CONFIG_KEYS:
     value = primary_config.get(key[0], fallback_config.get(key, key[1]))

--- a/orcoursetrion/lib/github.py
+++ b/orcoursetrion/lib/github.py
@@ -134,7 +134,7 @@ class GitHub(object):
             raise GitHubUnknownError(
                 'No teams found in {0} organization'.format(org)
             )
-        found_team = [x for x in teams if x['name'] == team]
+        found_team = [x for x in teams if x['name'].strip() == team.strip()]
         if len(found_team) != 1:
             raise GitHubNoTeamFound(
                 '{0} not in list of teams for {1}'.format(team, org)

--- a/orcoursetrion/tests/base.py
+++ b/orcoursetrion/tests/base.py
@@ -22,6 +22,7 @@ class TestGithubBase(unittest.TestCase):
     )
     TEST_TEAM = 'Test-Deploy'
     TEST_TEAM_ID = 1
+    TEST_STAGING_GR = 'http://gr/'
 
     def callback_repo_check(self, request, uri, headers, status_code=404):
         """Handle mocked API request for repo existence check."""

--- a/orcoursetrion/tests/base.py
+++ b/orcoursetrion/tests/base.py
@@ -5,6 +5,8 @@ Test base class with commonly used methods and variables
 import json
 import unittest
 
+import httpretty
+
 
 class TestGithubBase(unittest.TestCase):
     """Test Github actions and backing library."""
@@ -95,3 +97,71 @@ class TestGithubBase(unittest.TestCase):
                 "message": "Validation Failed",
             }))
         return (status_code, headers, '')
+
+    def register_repo_check(self, body):
+        """Register repo check URL and method."""
+        httpretty.register_uri(
+            httpretty.GET,
+            '{url}repos/{org}/{repo}'.format(
+                url=self.URL,
+                org=self.ORG,
+                repo=self.TEST_REPO
+            ),
+            body=body
+        )
+
+    def register_repo_create(self, body):
+        """Register url for repo create."""
+        httpretty.register_uri(
+            httpretty.POST,
+            '{url}orgs/{org}/repos'.format(
+                url=self.URL,
+                org=self.ORG,
+            ),
+            body=body
+        )
+
+    def register_hook_create(self, body, status):
+        """
+        Simple hook creation URL registration.
+        """
+        test_url = '{url}repos/{org}/{repo}/hooks'.format(
+            url=self.URL,
+            org=self.ORG,
+            repo=self.TEST_REPO
+        )
+        # Register for hook endpoint
+        httpretty.register_uri(
+            httpretty.POST,
+            test_url,
+            body=body,
+            status=status
+        )
+
+    def register_team_list(self, body):
+        """
+        Team listing API.
+        """
+        httpretty.register_uri(
+            httpretty.GET,
+            '{url}orgs/{org}/teams'.format(
+                url=self.URL,
+                org=self.ORG,
+            ),
+            body=body
+        )
+
+    def register_team_repo_add(self, body):
+        """
+        Register team repo addition.
+        """
+        httpretty.register_uri(
+            httpretty.PUT,
+            '{url}teams/{id}/repos/{org}/{repo}'.format(
+                url=self.URL,
+                id=self.TEST_TEAM_ID,
+                org=self.ORG,
+                repo=self.TEST_REPO
+            ),
+            body=body
+        )

--- a/orcoursetrion/tests/test_cmd.py
+++ b/orcoursetrion/tests/test_cmd.py
@@ -28,3 +28,26 @@ class TestGithubCommand(TestGithubBase):
                 mocked_actions.create_export_repo.assert_called_with(
                     self.TEST_COURSE, self.TEST_TERM, self.TEST_DESCRIPTION
                 )
+
+    def test_cmd_create_xml_repo(self):
+        """
+        Command line test of create_export_repo
+        """
+
+        args = [
+            'orcoursetrion', 'create_xml_repo',
+            '-c', self.TEST_COURSE,
+            '-t', self.TEST_TERM,
+            '-d', self.TEST_DESCRIPTION,
+            '-g', self.TEST_TEAM,
+        ]
+        with mock.patch('sys.argv', args):
+            with mock.patch('orcoursetrion.cmd.actions') as mocked_actions:
+                execute()
+                self.assertTrue(mocked_actions.create_xml_repo.called)
+                mocked_actions.create_xml_repo.assert_called_with(
+                    self.TEST_COURSE,
+                    self.TEST_TERM,
+                    self.TEST_TEAM,
+                    self.TEST_DESCRIPTION
+                )

--- a/orcoursetrion/tests/test_github.py
+++ b/orcoursetrion/tests/test_github.py
@@ -25,26 +25,8 @@ class TestGithub(TestGithubBase):
     def test_lib_create_repo_success(self):
         """Test the API call comes through as expected.
         """
-
-        # Register for repo check
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=self.callback_repo_check
-        )
-        # Register for repo create
-        httpretty.register_uri(
-            httpretty.POST,
-            '{url}orgs/{org}/repos'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=self.callback_repo_create
-        )
+        self.register_repo_check(self.callback_repo_check)
+        self.register_repo_create(self.callback_repo_create)
 
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         repo = git_hub.create_repo(
@@ -56,15 +38,8 @@ class TestGithub(TestGithubBase):
     def test_lib_create_repo_exists(self):
         """Test what happens when the repo exists."""
 
-        # Register for repo check
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_repo_check, status_code=200)
+        self.register_repo_check(
+            partial(self.callback_repo_check, status_code=200)
         )
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         with self.assertRaises(GitHubRepoExists):
@@ -73,30 +48,40 @@ class TestGithub(TestGithubBase):
             )
 
     @httpretty.activate
+    def test_lib_create_repo_unknown_errors(self):
+        """Test what happens when we don't get expected status_codes
+        """
+
+        self.register_repo_check(self.callback_repo_check)
+        self.register_repo_create(
+            partial(self.callback_repo_create, status_code=500)
+        )
+
+        git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
+        with self.assertRaises(GitHubUnknownError):
+            git_hub.create_repo(
+                self.ORG, self.TEST_REPO, self.TEST_DESCRIPTION
+            )
+        self.register_repo_check(
+            partial(self.callback_repo_check, status_code=422)
+        )
+        git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
+        with self.assertRaises(GitHubUnknownError):
+            git_hub.create_repo(
+                self.ORG, self.TEST_REPO, self.TEST_DESCRIPTION
+            )
+
+    @httpretty.activate
     def test_lib_create_hook(self):
         """Test valid hook creation"""
-
-        test_url = '{url}repos/{org}/{repo}/hooks'.format(
-            url=self.URL,
-            org=self.ORG,
-            repo=self.TEST_REPO
-        )
-        # Register for hook endpoint
-        httpretty.register_uri(
-            httpretty.POST,
-            test_url,
-            body=json.dumps({'id': 1}),
-            status=201
-        )
+        self.register_hook_create(json.dumps({'id': 1}), status=201)
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         # Will raise if it is invalid
         git_hub.add_web_hook(self.ORG, self.TEST_REPO, 'http://fluff')
 
         # Setup for failure mode
         error_body = json.dumps({u'message': u'Validation Failed'})
-        httpretty.register_uri(
-            httpretty.POST,
-            test_url,
+        self.register_hook_create(
             body=error_body,
             status=422
         )
@@ -104,77 +89,11 @@ class TestGithub(TestGithubBase):
             git_hub.add_web_hook(self.ORG, self.TEST_REPO, 'http://fluff')
 
     @httpretty.activate
-    def test_lib_create_repo_unknown_errors(self):
-        """Test what happens when we don't get expected status_codes
-        """
-
-        # Register for repo check
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=self.callback_repo_check
-        )
-        # Register for repo create
-        httpretty.register_uri(
-            httpretty.POST,
-            '{url}orgs/{org}/repos'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_repo_create, status_code=500)
-        )
-
-        git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
-        with self.assertRaises(GitHubUnknownError):
-            git_hub.create_repo(
-                self.ORG, self.TEST_REPO, self.TEST_DESCRIPTION
-            )
-
-        # Register for repo check with bad something or other
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_repo_check, status_code=422)
-        )
-        git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
-        with self.assertRaises(GitHubUnknownError):
-            git_hub.create_repo(
-                self.ORG, self.TEST_REPO, self.TEST_DESCRIPTION
-            )
-
-    @httpretty.activate
     def test_lib_add_team_repo_success(self):
         """Test what happens when we don't get expected status_codes
         """
-
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list, more=True)
-        )
-        # Register for team repo add API
-        httpretty.register_uri(
-            httpretty.PUT,
-            '{url}teams/{id}/repos/{org}/{repo}'.format(
-                url=self.URL,
-                id=self.TEST_TEAM_ID,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_team_repo)
-        )
+        self.register_team_list(partial(self.callback_team_list, more=True))
+        self.register_team_repo_add(self.callback_team_repo)
 
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         # This will raise on any failures
@@ -184,15 +103,8 @@ class TestGithub(TestGithubBase):
     def test_lib_add_team_repo_no_teams(self):
         """Test what happens when we don't have any teams
         """
-
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list, status_code=404)
+        self.register_team_list(
+            partial(self.callback_team_list, status_code=404)
         )
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         # See how we handle no teams
@@ -206,16 +118,7 @@ class TestGithub(TestGithubBase):
     def test_lib_add_team_repo_team_not_found(self):
         """Test what happens when the team isn't in the org
         """
-
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list)
-        )
+        self.register_team_list(self.callback_team_list)
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
         with self.assertRaises(GitHubNoTeamFound):
             git_hub.add_team_repo(self.ORG, self.TEST_REPO, 'foobar')
@@ -237,26 +140,9 @@ class TestGithub(TestGithubBase):
     def test_lib_add_team_repo_fail(self):
         """Test what happens when the repo can't be added to the team
         """
-
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list)
-        )
-        # Register for team repo add API
-        httpretty.register_uri(
-            httpretty.PUT,
-            '{url}teams/{id}/repos/{org}/{repo}'.format(
-                url=self.URL,
-                id=self.TEST_TEAM_ID,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_team_repo, status_code=422)
+        self.register_team_list(self.callback_team_list)
+        self.register_team_repo_add(
+            partial(self.callback_team_repo, status_code=422)
         )
 
         git_hub = GitHub(self.URL, self.OAUTH2_TOKEN)
@@ -278,45 +164,12 @@ class TestGithub(TestGithubBase):
         config.ORC_STUDIO_ORG = self.ORG
         config.ORC_STUDIO_DEPLOY_TEAM = self.TEST_TEAM
 
-        # Register for repo check
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=self.callback_repo_check
+        self.register_repo_check(self.callback_repo_check)
+        self.register_repo_create(self.callback_repo_create)
+        self.register_team_list(
+            partial(self.callback_team_list, more=True)
         )
-        # Repo creation register
-        httpretty.register_uri(
-            httpretty.POST,
-            '{url}orgs/{org}/repos'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=self.callback_repo_create
-        )
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list, more=True)
-        )
-        # Register for team repo add API
-        httpretty.register_uri(
-            httpretty.PUT,
-            '{url}teams/{id}/repos/{org}/{repo}'.format(
-                url=self.URL,
-                id=self.TEST_TEAM_ID,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_team_repo)
-        )
+        self.register_team_repo_add(self.callback_team_repo)
 
         create_export_repo(
             self.TEST_COURSE,
@@ -336,55 +189,15 @@ class TestGithub(TestGithubBase):
         config.ORC_XML_DEPLOY_TEAM = self.TEST_TEAM
         config.ORC_STAGING_GITRELOAD = self.TEST_STAGING_GR
 
-        # Register for repo check
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}repos/{org}/{repo}'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=self.callback_repo_check
+        self.register_repo_check(self.callback_repo_check)
+        self.register_repo_create(self.callback_repo_create)
+        self.register_team_list(
+            partial(self.callback_team_list, more=True)
         )
-        # Register repo create
-        httpretty.register_uri(
-            httpretty.POST,
-            '{url}orgs/{org}/repos'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=self.callback_repo_create
-        )
-        # Register for hook endpoint
-        httpretty.register_uri(
-            httpretty.POST,
-            '{url}repos/{org}/{repo}/hooks'.format(
-                url=self.URL,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
+        self.register_team_repo_add(self.callback_team_repo)
+        self.register_hook_create(
             body=json.dumps({'id': 1}),
             status=201
-        )
-        # Register for team list API
-        httpretty.register_uri(
-            httpretty.GET,
-            '{url}orgs/{org}/teams'.format(
-                url=self.URL,
-                org=self.ORG,
-            ),
-            body=partial(self.callback_team_list, more=True)
-        )
-        # Register for team repo add API
-        httpretty.register_uri(
-            httpretty.PUT,
-            '{url}teams/{id}/repos/{org}/{repo}'.format(
-                url=self.URL,
-                id=self.TEST_TEAM_ID,
-                org=self.ORG,
-                repo=self.TEST_REPO
-            ),
-            body=partial(self.callback_team_repo)
         )
 
         create_xml_repo(


### PR DESCRIPTION
This adds the action to create an XML course repository with a git hook to staging, a collaboration team, and the content deployment team.

There is a also a refactor of the tests to use functions for registering URLs to help clean things up and reduce repetition in tests.