### PR TITLE
Adds `release_studio` and `release_xml` actions and commands

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,3 +61,8 @@ Configuration options
                  server URL (including username and password) for the
                  course development LMS.
 
+.. autoattribute:: orcoursetrion.config.ORC_PRODUCTION_GITRELOAD
+    :annotation: = `gitreload <https://github.com/mitodl/gitreload>`_
+                 server URL (including username and password) for the
+                 course production LMS.
+

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -30,6 +30,11 @@ Available Actions
    ``term`` and then create a new repo with the ``new_term``, along
    with the :py:attr:`~orcoursetrion.config.ORC_STUDIO_DEPLOY_TEAM` added.
 
+:release_studio:
+
+   This will add the production git Web hook to the course specified
+   with :py:attr:`~orcoursetrion.config.ORC_PRODUCTION_GITRELOAD`.
+
 :create_xml_repo:
 
    This will create a new repository with the
@@ -44,6 +49,11 @@ Available Actions
 
    This will rerun an XML course.  Currently this will just remove any
    Web hooks that are currently attached to the repository.
+
+:release_xml:
+
+   This will add the production git Web hook to the course specified
+   with :py:attr:`~orcoursetrion.config.ORC_PRODUCTION_GITRELOAD`.
 
 :put_team:
 

--- a/orcoursetrion/actions/__init__.py
+++ b/orcoursetrion/actions/__init__.py
@@ -5,8 +5,10 @@ Action library access
 from orcoursetrion.actions.github import (
     create_export_repo,
     rerun_studio,
+    release_studio,
     create_xml_repo,
     rerun_xml,
+    release_xml,
     put_team
 )
 
@@ -14,7 +16,9 @@ from orcoursetrion.actions.github import (
 __all__ = [
     'create_export_repo',
     'rerun_studio',
+    'release_studio',
     'create_xml_repo',
     'rerun_xml',
+    'release_xml',
     'put_team',
 ]

--- a/orcoursetrion/actions/github.py
+++ b/orcoursetrion/actions/github.py
@@ -62,6 +62,7 @@ def rerun_studio(course, term, new_term, description=None):
         description (str): Optional description for repo to show up on github
     Raises:
         requests.RequestException
+        orcoursetrion.lib.GitHubRepoDoesNotExist
         orcoursetrion.lib.GitHubUnknownError
     Returns:
         dict: Github dictionary of the newly created repo
@@ -91,6 +92,35 @@ def rerun_studio(course, term, new_term, description=None):
         config.ORC_STUDIO_ORG, repo_name, config.ORC_STUDIO_DEPLOY_TEAM
     )
     return repo
+
+
+def release_studio(course, term):
+    """Moves a studio course to be ready for production.
+
+    Currently this will just add a hook to the production server, but
+    it will eventually take care of everything else needed for a
+    transfer as well.
+
+    Args:
+        course (str): Course name of the repo to release to production
+                      (i.e. 6.001)
+        term (str): Term the course is currently running in (i.e. 2015_Spring)
+    Raises:
+        requests.RequestException
+        orcoursetrion.lib.GitHubUnknownError
+    Returns:
+        None: Nothing returned, raises on failure
+    """
+    github = GitHub(config.ORC_GH_API_URL, config.ORC_GH_OAUTH2_TOKEN)
+    repo_name = '{prefix}-{course}-{term}'.format(
+        prefix=config.ORC_COURSE_PREFIX,
+        course=course.replace('.', ''),
+        term=term
+    )
+    # Add the hook
+    github.add_web_hook(
+        config.ORC_STUDIO_ORG, repo_name, config.ORC_PRODUCTION_GITRELOAD
+    )
 
 
 def create_xml_repo(course, term, team, members=None, description=None):
@@ -177,6 +207,35 @@ def rerun_xml(course, term):
         term=term
     )
     return github.delete_web_hooks(config.ORC_XML_ORG, repo_name)
+
+
+def release_xml(course, term):
+    """Moves an XML course to be ready for production.
+
+    Currently this will just add a hook to the production server, but
+    it will eventually take care of everything else needed for a
+    transfer as well (i.e. making live branch, import it to lms...).
+
+    Args:
+        course (str): Course name of the repo to release to production
+                      (i.e. 6.001)
+        term (str): Term the course is currently running in (i.e. 2015_Spring)
+    Raises:
+        requests.RequestException
+        orcoursetrion.lib.GitHubUnknownError
+    Returns:
+        None: Nothing returned, raises on failure
+    """
+    github = GitHub(config.ORC_GH_API_URL, config.ORC_GH_OAUTH2_TOKEN)
+    repo_name = '{prefix}-{course}-{term}'.format(
+        prefix=config.ORC_COURSE_PREFIX,
+        course=course.replace('.', ''),
+        term=term
+    )
+    # Add the hook
+    github.add_web_hook(
+        config.ORC_XML_ORG, repo_name, config.ORC_PRODUCTION_GITRELOAD
+    )
 
 
 def put_team(org, team, read_only, members):

--- a/orcoursetrion/cmd.py
+++ b/orcoursetrion/cmd.py
@@ -30,6 +30,12 @@ def run_rerun_studio(args):
     )
 
 
+def run_release_studio(args):
+    """Run the release_studio action using args"""
+    actions.release_studio(args.course, args.term)
+    print('Added production Web hooks to course')
+
+
 def run_create_xml_repo(args):
     """Run the create_xml_repo action using args"""
     repo = actions.create_xml_repo(
@@ -50,6 +56,12 @@ def run_rerun_xml(args):
             num_deleted_hooks
         )
     )
+
+
+def run_release_xml(args):
+    """Run the release_xml action using args"""
+    actions.release_xml(args.course, args.term)
+    print('Added production Web hooks to course')
 
 
 def run_put_team(args):
@@ -112,6 +124,21 @@ def execute():
     )
     rerun_studio.set_defaults(func=run_rerun_studio)
 
+    # Release Studio Course
+    release_studio = subparsers.add_parser(
+        'release_studio',
+        help='Release a Studio course (currently just add Web hooks)'
+    )
+    release_studio.add_argument(
+        '-c', '--course', type=str, required=True,
+        help='Course to work on (i.e. 6.0001)'
+    )
+    release_studio.add_argument(
+        '-t', '--term', type=str, required=True,
+        help='Term of the course (i.e. Spring_2015)'
+    )
+    release_studio.set_defaults(func=run_release_studio)
+
     # Create XML repository
     create_xml_repo = subparsers.add_parser(
         'create_xml_repo',
@@ -153,6 +180,21 @@ def execute():
         help='Term of the course (i.e. Spring_2015)'
     )
     rerun_xml.set_defaults(func=run_rerun_xml)
+
+    # Release XML Course
+    release_xml = subparsers.add_parser(
+        'release_xml',
+        help='Release an XML course (currently just adds Web hooks)'
+    )
+    release_xml.add_argument(
+        '-c', '--course', type=str, required=True,
+        help='Course to work on (i.e. 6.0001)'
+    )
+    release_xml.add_argument(
+        '-t', '--term', type=str, required=True,
+        help='Term of the course (i.e. Spring_2015)'
+    )
+    release_xml.set_defaults(func=run_release_xml)
 
     # Create/Modify Team
     put_team = subparsers.add_parser(

--- a/orcoursetrion/config.py
+++ b/orcoursetrion/config.py
@@ -41,6 +41,9 @@ CONFIG_KEYS = [
 
     # Web hook URL (including basic auth) for course development LMS
     ('ORC_STAGING_GITRELOAD', None),
+
+    # Web hook URL (including basic auth) for course production LMS
+    ('ORC_PRODUCTION_GITRELOAD', None),
 ]
 for key in CONFIG_KEYS:
     value = primary_config.get(key[0], fallback_config.get(key, key[1]))

--- a/orcoursetrion/tests/base.py
+++ b/orcoursetrion/tests/base.py
@@ -31,6 +31,7 @@ class TestGithubBase(unittest.TestCase):
     TEST_TEAM_ID = 1
     TEST_TEAM_MEMBERS = ['archlight', 'bizarnage', 'chemistro', 'dreadnought']
     TEST_STAGING_GR = 'http://gr/'
+    TEST_PRODUCTION_GR = 'http://prod-gr/'
 
     def callback_repo_check(self, request, uri, headers, status_code=404):
         """Handle mocked API request for repo existence check."""

--- a/orcoursetrion/tests/test_cmd.py
+++ b/orcoursetrion/tests/test_cmd.py
@@ -50,6 +50,25 @@ class TestGithubCommand(TestGithubBase):
                     self.TEST_NEW_TERM
                 )
 
+    def test_cmd_release_studio(self):
+        """
+        Command line test of release_studio
+        """
+
+        args = [
+            'orcoursetrion', 'release_studio',
+            '-c', self.TEST_COURSE,
+            '-t', self.TEST_TERM,
+        ]
+        with mock.patch('sys.argv', args):
+            with mock.patch('orcoursetrion.cmd.actions') as mocked_actions:
+                execute()
+                self.assertTrue(mocked_actions.release_studio.called)
+                mocked_actions.release_studio.assert_called_with(
+                    self.TEST_COURSE,
+                    self.TEST_TERM,
+                )
+
     def test_cmd_create_xml_repo(self):
         """
         Command line test of create_export_repo
@@ -108,6 +127,25 @@ class TestGithubCommand(TestGithubBase):
                 execute()
                 self.assertTrue(mocked_actions.rerun_xml.called)
                 mocked_actions.rerun_xml.assert_called_with(
+                    self.TEST_COURSE,
+                    self.TEST_TERM,
+                )
+
+    def test_cmd_release_xml(self):
+        """
+        Command line test of release_xml
+        """
+
+        args = [
+            'orcoursetrion', 'release_xml',
+            '-c', self.TEST_COURSE,
+            '-t', self.TEST_TERM,
+        ]
+        with mock.patch('sys.argv', args):
+            with mock.patch('orcoursetrion.cmd.actions') as mocked_actions:
+                execute()
+                self.assertTrue(mocked_actions.release_xml.called)
+                mocked_actions.release_xml.assert_called_with(
                     self.TEST_COURSE,
                     self.TEST_TERM,
                 )

--- a/orcoursetrion/tests/test_github.py
+++ b/orcoursetrion/tests/test_github.py
@@ -12,9 +12,11 @@ import mock
 from orcoursetrion.actions import (
     create_export_repo,
     rerun_studio,
+    release_studio,
     create_xml_repo,
+    rerun_xml,
+    release_xml,
     put_team,
-    rerun_xml
 )
 from orcoursetrion.lib import (
     GitHub,
@@ -394,6 +396,25 @@ class TestGithub(TestGithubBase):
 
     @mock.patch('orcoursetrion.actions.github.config')
     @httpretty.activate
+    def test_actions_release_studio_success(self, config):
+        """Test the API call comes through as expected.
+        """
+        config.ORC_GH_OAUTH2_TOKEN = self.OAUTH2_TOKEN
+        config.ORC_GH_API_URL = self.URL
+        config.ORC_COURSE_PREFIX = self.TEST_PREFIX
+        config.ORC_STUDIO_ORG = self.ORG
+        config.ORC_PRODUCTION_GITRELOAD = self.TEST_PRODUCTION_GR
+
+        self.register_hook_create(json.dumps({'id': 2}), status=201)
+        self.register_team_repo_add(self.callback_team_repo)
+
+        release_studio(
+            self.TEST_COURSE,
+            self.TEST_TERM,
+        )
+
+    @mock.patch('orcoursetrion.actions.github.config')
+    @httpretty.activate
     def test_actions_create_xml_repo_success(self, config):
         """Test the API call comes through as expected.
         """
@@ -463,6 +484,25 @@ class TestGithub(TestGithubBase):
         self.register_hook_delete()
         hooks_deleted = rerun_xml(self.TEST_COURSE, self.TEST_TERM)
         self.assertEqual(1, hooks_deleted)
+
+    @mock.patch('orcoursetrion.actions.github.config')
+    @httpretty.activate
+    def test_actions_release_XML_success(self, config):
+        """Test the API call comes through as expected.
+        """
+        config.ORC_GH_OAUTH2_TOKEN = self.OAUTH2_TOKEN
+        config.ORC_GH_API_URL = self.URL
+        config.ORC_COURSE_PREFIX = self.TEST_PREFIX
+        config.ORC_XML_ORG = self.ORG
+        config.ORC_PRODUCTION_GITRELOAD = self.TEST_PRODUCTION_GR
+
+        self.register_hook_create(json.dumps({'id': 2}), status=201)
+        self.register_team_repo_add(self.callback_team_repo)
+
+        release_xml(
+            self.TEST_COURSE,
+            self.TEST_TERM,
+        )
 
     @mock.patch('orcoursetrion.actions.github.config')
     @httpretty.activate


### PR DESCRIPTION
Based on #27 because I forgot to start a new feature branch, and the code was really similar, so there was quite a bit of copy pasting advantages from having it based on that branch.  As a result you probably will want to do the review of just the second commit (currently c0281e0c23bc1275085c67e3edcd7b0cdcf227b3) if you review this first.