### PR TITLE
commit initial course.xml when running create_export_repo

### DIFF
--- a/orcoursetrion/actions/github.py
+++ b/orcoursetrion/actions/github.py
@@ -61,6 +61,16 @@ def create_export_repo(course, term, description=None):
         path=GITIGNORE_PATH,
         contents=GITIGNORE_CONTENTS
     )
+    
+    # Add initial course.xml file
+    github.add_repo_file(
+        org=config.ORC_STUDIO_ORG,
+        repo=repo_name,
+        committer=COMMITTER,
+        message='initial commit of course.xml with term "{term}"'.format(term=term),
+        path="course.xml",
+        contents='<course url_name="{term}" org="MITx" course="{course}"/>\n'.format(term=term,course=course) 
+    )
 
     return repo
 


### PR DESCRIPTION
#### What are the relevant tickets?

part of mitodl/edx-platform#31

#### What's this PR do?

When create repos for use with gitexport it includes a commit with a message that includes the course run information. This information is otherwise omitted from course exports. 

#### How should this be manually tested?

clone this branch:
```
git clone git@github.com:mitodl/orcoursetrion.git
cd orcoursetrion
git checkout -b pdpinch/fix-missing-run origin/pdpinch/fix-missing-run
```
uninstall any existing version of orcoursetrion and install this version:
```
pip uninstall orcoursetrion
pip install -e .
```
create a new export repo and confirm that it includes a commit with the expect message:
```
orcoursetrion create_export_repo -c {course_number} -t {run}
cd content-mit-{course_number}-{run}
git log
```
If you see a commit with the message `initial commit of course.xml with term "{run}"` then it worked!

#### Any background context you want to provide?

This commit message will be used to identify the run inside the repo, so that subsequent executions of this [git pre-commit hook](https://raw.githubusercontent.com/mitodl/salt-ops/a1b95a517b9f1163480ab932199a7840c8c3679d/salt/edx/files/edx_export_pre_commit.sh) will modify the exported course to contain the legacy run information.  
