### PR TITLE
bumping version to 0.2.1

### DIFF
--- a/orcoursetrion/__init__.py
+++ b/orcoursetrion/__init__.py
@@ -3,4 +3,4 @@
 Automation kit for provisioning courses for MITx platform
 """
 
-VERSION = '0.1.1'
+VERSION = '0.2.1'


### PR DESCRIPTION
#### What are the relevant tickets?

None

#### What's this PR do?

Bumps version to 0.2.1 because my prior version bump wasn't merged somehow

